### PR TITLE
feat: add conform.nvim configuration

### DIFF
--- a/nvim/lua/plugins/conform.lua
+++ b/nvim/lua/plugins/conform.lua
@@ -1,0 +1,48 @@
+local config = function()
+  require('conform').setup({
+    formatters_by_ft = {
+      lua = { "stylua" },
+      python = { "isort", "black" },
+      javascript = { { "prettierd", "prettier" } },
+      typescript = { { "prettierd", "prettier" } },
+      javascriptreact = { { "prettierd", "prettier" } },
+      typescriptreact = { { "prettierd", "prettier" } },
+      vue = { { "prettierd", "prettier" } },
+      css = { { "prettierd", "prettier" } },
+      scss = { { "prettierd", "prettier" } },
+      less = { { "prettierd", "prettier" } },
+      html = { { "prettierd", "prettier" } },
+      json = { { "prettierd", "prettier" } },
+      jsonc = { { "prettierd", "prettier" } },
+      yaml = { { "prettierd", "prettier" } },
+      markdown = { { "prettierd", "prettier" } },
+      graphql = { { "prettierd", "prettier" } },
+      handlebars = { "prettier" },
+      go = { "goimports", "gofmt" },
+      rust = { "rustfmt" },
+      sh = { "shfmt" },
+      ruby = { "rubocop" },
+    },
+    format_on_save = {
+      timeout_ms = 500,
+      lsp_fallback = true,
+    },
+  })
+
+  -- Key mappings for manual formatting
+  vim.keymap.set({ "n", "v" }, "<leader>f", function()
+    require("conform").format({
+      lsp_fallback = true,
+      async = false,
+      timeout_ms = 500,
+    })
+  end, { desc = "Format file or range (in visual mode)" })
+end
+
+---@type LazySpec
+local spec = {
+  'stevearc/conform.nvim',
+  opts = {},
+  config = config,
+}
+return spec


### PR DESCRIPTION
Add conform.nvim to Neovim configuration for code formatting

This PR adds a new plugin configuration file for conform.nvim under lua/plugins/ as requested in issue #2.

**Changes:**
- Created `nvim/lua/plugins/conform.lua` with comprehensive formatter support
- Configured formatters for multiple languages (Lua, Python, JS/TS, Go, Rust, Ruby, etc.)
- Enabled format on save functionality
- Added manual formatting key mapping (<leader>f)
- Configured fallback to LSP formatting

Closes #2

Generated with [Claude Code](https://claude.ai/code)